### PR TITLE
Add support for SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This plugin only works with embulk >= 0.8.8.
     - **user**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
-    - **tls_enable**: enable/disable tls (boolean, optional, default false)
-    - **tls_insecure**: enable/disable certificate and host validation (boolean, optional, default false)
+    - **tls**: enable/disable tls (boolean, optional, default false)
+    - **tls_insecure**: enable/disable certificate and host validation (boolean, optional, default false), this option similar to option supported by mongo command (https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure)
 - **collection**: source collection name (string, required)
 - **fields**: **(deprecated)** ~~hash records that has the following two fields (array, required)~~
   ~~- name: Name of the column~~

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ This plugin only works with embulk >= 0.8.8.
     - **user**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
-    - **tls**: enable/disable tls (boolean, optional, default false)
-    - **tls_insecure**: enable/disable certificate and host validation (boolean, optional, default false), this option similar to option supported by mongo command (https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure)
+    - **tls**: `true` to use TLS to connect to the host (boolean, optional, default: `false`)
+    - **tls_insecure**: `true` to disable various certificate validations (boolean, optional, default: `false`)
+      - The option is similar to an option of the official `mongo` command.
+      - See also: https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure
 - **collection**: source collection name (string, required)
 - **fields**: **(deprecated)** ~~hash records that has the following two fields (array, required)~~
   ~~- name: Name of the column~~

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This plugin only works with embulk >= 0.8.8.
     - **user**: (string, optional)
     - **password**:  (string, optional)
     - **database**:  (string, required)
+    - **tls_enable**: enable/disable tls (boolean, optional, default false)
+    - **tls_insecure**: enable/disable certificate and host validation (boolean, optional, default false)
 - **collection**: source collection name (string, required)
 - **fields**: **(deprecated)** ~~hash records that has the following two fields (array, required)~~
   ~~- name: Name of the column~~

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.8.1-SNAPSHOT"
+version = "0.8.2-SNAPSHOT"
 description = "Loads records from Mongodb."
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -19,6 +19,7 @@ package org.embulk.input.mongodb;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoException;
@@ -34,7 +35,6 @@ import org.bson.json.JsonParseException;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.DataSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.BufferAllocator;
@@ -52,8 +52,14 @@ import org.msgpack.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -123,7 +129,7 @@ public class MongodbInputPlugin
             throw new ConfigException(ex);
         }
         Schema schema = Schema.builder().add(task.getJsonColumnName(), Types.JSON).build();
-        return resume(task.dump(), schema, 1, control);
+        return resume(task.toTaskSource(), schema, 1, control);
     }
 
     @Override
@@ -157,7 +163,7 @@ public class MongodbInputPlugin
         final TaskMapper taskMapper = CONFIG_MAPPER_FACTORY.createTaskMapper();
         final PluginTask task = taskMapper.map(taskSource, PluginTask.class);
         BufferAllocator allocator = Exec.getBufferAllocator();
-        PageBuilder pageBuilder = new PageBuilder(allocator, schema, output);
+        PageBuilder pageBuilder = Exec.getPageBuilder(allocator, schema, output);
         final Column column = pageBuilder.getSchema().getColumns().get(0);
 
         ValueCodec valueCodec = new ValueCodec(task.getStopOnInvalidRecord(), task);
@@ -324,10 +330,52 @@ public class MongodbInputPlugin
         }
 
         if (task.getUser().isPresent()) {
-            return new MongoClient(addresses, Arrays.asList(createCredential(task)));
+            return new MongoClient(addresses, Arrays.asList(createCredential(task)), createMongoClientOptions(task));
         }
         else {
-            return new MongoClient(addresses);
+            return new MongoClient(addresses, createMongoClientOptions(task));
+        }
+    }
+
+    private MongoClientOptions createMongoClientOptions(PluginTask task)
+    {
+        MongoClientOptions.Builder builder = new MongoClientOptions.Builder();
+        if (task.getTlsEnable()) {
+            builder.sslEnabled(true);
+            if (task.getTlsInsecure()) {
+                builder.sslInvalidHostNameAllowed(true);
+                builder.sslContext(createAcceptAllCertificate());
+            }
+        }
+        return builder.build();
+    }
+
+    private SSLContext createAcceptAllCertificate()
+    {
+        TrustManager[] trustAllCerts = new TrustManager[] {
+                new X509TrustManager()
+                {
+                    public X509Certificate[] getAcceptedIssuers()
+                    {
+                        return new X509Certificate[0];
+                    }
+                    public void checkClientTrusted(
+                            X509Certificate[] certs, String authType)
+                    {
+                    }
+                    public void checkServerTrusted(
+                            X509Certificate[] certs, String authType)
+                    {
+                    }
+                }
+        };
+        try {
+            SSLContext sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            return sc;
+        }
+        catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new ConfigException(e);
         }
     }
 

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -344,13 +344,13 @@ public class MongodbInputPlugin
             builder.sslEnabled(true);
             if (task.getTlsInsecure()) {
                 builder.sslInvalidHostNameAllowed(true);
-                builder.sslContext(createAcceptAllCertificate());
+                builder.sslContext(createSSLContextToAcceptAnyCert());
             }
         }
         return builder.build();
     }
 
-    private SSLContext createAcceptAllCertificate()
+    private SSLContext createSSLContextToAcceptAnyCert()
     {
         TrustManager[] trustAllCerts = new TrustManager[] {
                 new X509TrustManager()

--- a/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
+++ b/src/main/java/org/embulk/input/mongodb/MongodbInputPlugin.java
@@ -340,7 +340,7 @@ public class MongodbInputPlugin
     private MongoClientOptions createMongoClientOptions(PluginTask task)
     {
         MongoClientOptions.Builder builder = new MongoClientOptions.Builder();
-        if (task.getTlsEnable()) {
+        if (task.getTls()) {
             builder.sslEnabled(true);
             if (task.getTlsInsecure()) {
                 builder.sslInvalidHostNameAllowed(true);

--- a/src/main/java/org/embulk/input/mongodb/PluginTask.java
+++ b/src/main/java/org/embulk/input/mongodb/PluginTask.java
@@ -39,10 +39,11 @@ public interface PluginTask
     @ConfigDefault("null")
     Optional<List<HostTask>> getHosts();
 
-    @Config("tls_enable")
+    @Config("tls")
     @ConfigDefault("false")
-    boolean getTlsEnable();
+    boolean getTls();
 
+    // similar to option supported by mongo command (https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure)
     @Config("tls_insecure")
     @ConfigDefault("false")
     boolean getTlsInsecure();

--- a/src/main/java/org/embulk/input/mongodb/PluginTask.java
+++ b/src/main/java/org/embulk/input/mongodb/PluginTask.java
@@ -39,6 +39,14 @@ public interface PluginTask
     @ConfigDefault("null")
     Optional<List<HostTask>> getHosts();
 
+    @Config("tls_enable")
+    @ConfigDefault("false")
+    boolean getTlsEnable();
+
+    @Config("tls_insecure")
+    @ConfigDefault("false")
+    boolean getTlsInsecure();
+
     @Config("auth_method")
     @ConfigDefault("null")
     Optional<AuthMethod> getAuthMethod();

--- a/src/main/java/org/embulk/input/mongodb/PluginTask.java
+++ b/src/main/java/org/embulk/input/mongodb/PluginTask.java
@@ -43,7 +43,8 @@ public interface PluginTask
     @ConfigDefault("false")
     boolean getTls();
 
-    // similar to option supported by mongo command (https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure)
+    // The option is similar to an option of the official `mongo` command.
+    // (https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.tlsInsecure)
     @Config("tls_insecure")
     @ConfigDefault("false")
     boolean getTlsInsecure();

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCredential;
 import com.mongodb.client.MongoCollection;
@@ -40,7 +41,6 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Column;
-import org.embulk.spi.Exec;
 import org.embulk.spi.InputPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TestPageBuilderReader.MockPageOutput;
@@ -238,11 +238,54 @@ public class TestMongodbInputPlugin
     }
 
     @Test
+    public void testCreateMongoClientOptionsTLSEnableWithInsecureEnable() throws Exception
+    {
+        final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
+                configForAuth().deepCopy()
+                        .set("tls_enable", "true")
+                        .set("tls_insecure", "true"),
+                PluginTask.class);
+        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
+        createMongoClientOptions.setAccessible(true);
+        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
+        assertThat(true, is(mongoClientOptions.isSslEnabled()));
+        assertThat(true, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+    }
+
+    @Test
+    public void testCreateMongoClientOptionsTLSEnableWithInsecureDisable() throws Exception
+    {
+        final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
+                configForAuth().deepCopy()
+                        .set("tls_enable", "true"),
+                PluginTask.class);
+        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
+        createMongoClientOptions.setAccessible(true);
+        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
+        assertThat(true, is(mongoClientOptions.isSslEnabled()));
+        assertThat(false, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+    }
+
+    @Test
+    public void testCreateMongoClientOptionsTLSDisable() throws Exception
+    {
+        final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
+                configForAuth().deepCopy()
+                        .set("tls_enable", "false"),
+                PluginTask.class);
+        Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
+        createMongoClientOptions.setAccessible(true);
+        MongoClientOptions mongoClientOptions = (MongoClientOptions) createMongoClientOptions.invoke(plugin, task);
+        assertThat(false, is(mongoClientOptions.isSslEnabled()));
+        assertThat(false, is(mongoClientOptions.isSslInvalidHostNameAllowed()));
+    }
+
+    @Test
     public void testResume()
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
         final Schema schema = getFieldSchema();
-        plugin.resume(task.dump(), schema, 0, new InputPlugin.Control() {
+        plugin.resume(task.toTaskSource(), schema, 0, new InputPlugin.Control() {
             @Override
             public List<TaskReport> run(TaskSource taskSource, Schema schema, int taskCount)
             {

--- a/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
+++ b/src/test/java/org/embulk/input/mongodb/TestMongodbInputPlugin.java
@@ -242,7 +242,7 @@ public class TestMongodbInputPlugin
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
-                        .set("tls_enable", "true")
+                        .set("tls", "true")
                         .set("tls_insecure", "true"),
                 PluginTask.class);
         Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
@@ -257,7 +257,7 @@ public class TestMongodbInputPlugin
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
-                        .set("tls_enable", "true"),
+                        .set("tls", "true"),
                 PluginTask.class);
         Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
         createMongoClientOptions.setAccessible(true);
@@ -271,7 +271,7 @@ public class TestMongodbInputPlugin
     {
         final PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(
                 configForAuth().deepCopy()
-                        .set("tls_enable", "false"),
+                        .set("tls", "false"),
                 PluginTask.class);
         Method createMongoClientOptions = MongodbInputPlugin.class.getDeclaredMethod("createMongoClientOptions", PluginTask.class);
         createMongoClientOptions.setAccessible(true);


### PR DESCRIPTION
The current implementation doesn't support SSL(TLS). This PR will add two options to support TLS

tls_enable: enable/disable tls (boolean, optional, default false)
tls_insecure: if false, certificate and host is validated. Otherwise, skip validated (boolean, optional, default false)